### PR TITLE
[vpc] Adding provider configuration for AWS

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -9,4 +9,6 @@ terraform {
 
 # Configure the AWS Provider
 provider "aws" {
+  region  = "us-east-1"
+  profile = "dev"
 }


### PR DESCRIPTION
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.vpc.aws_vpc.vpc_use1 will be created
  + resource "aws_vpc" "vpc_use1" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "env" = "dev"
        }
      + tags_all                             = {
          + "env" = "dev"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```